### PR TITLE
Typos and fix xml cross references

### DIFF
--- a/draft-ietf-sidrops-rpki-validation-update.xml
+++ b/draft-ietf-sidrops-rpki-validation-update.xml
@@ -187,7 +187,7 @@
               Validation of signed resource data using a target resource certificate consists of verifying that the digital signature of the signed resource data is valid, using the public key of the target resource certificate, and also validating the resource certificate in the context of the RPKI, using the path validation process.
             </t>
             <t>
-              There are two inputs to the validation algortihm:
+              There are two inputs to the validation algorithm:
               <list style="numbers">
                 <t>A trust anchor</t>
                 <t>A certificate to be validated</t>
@@ -300,7 +300,7 @@
   <section title="Security Considerations">
 
     <t>
-      The authors believe that the revised validation algortihm introduces no new security vulnerabilities into the RPKI, because it cannot lead to any ROA and/or router certificates to be accepted if they contain resources that are not held by the issuer.
+      The authors believe that the revised validation algorithm introduces no new security vulnerabilities into the RPKI, because it cannot lead to any ROA and/or router certificates to be accepted if they contain resources that are not held by the issuer.
     </t>
 
   </section>

--- a/draft-ietf-sidrops-rpki-validation-update.xml
+++ b/draft-ietf-sidrops-rpki-validation-update.xml
@@ -8,7 +8,8 @@
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
 
-<rfc category="std"
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude"
+     category="std"
      docName="draft-ietf-sidrops-rpki-validation-update-01"
      updates="6487,9582"
      obsoletes="8360"
@@ -358,13 +359,13 @@
 
 <back>
   <references title="Normative References">
-    <?rfc include="reference.RFC.2119.xml"?>
-    <?rfc include="reference.RFC.3779.xml"?>
-    <?rfc include="reference.RFC.5280.xml"?>
-    <?rfc include="reference.RFC.6487.xml"?>
-    <?rfc include="reference.RFC.8174.xml"?>
-    <?rfc include="reference.RFC.8360.xml"?>
-    <?rfc include="reference.RFC.9582.xml"?>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.3779.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.5280.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6487.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8360.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9582.xml"/>
   </references>
 
   <references title="Informative References">


### PR DESCRIPTION
This gets rid of the warnings by xml2rfc without changing the .txt or .html output.